### PR TITLE
Added support for a user whitelist in idlemove

### DIFF
--- a/modules-available/idlemove.ini
+++ b/modules-available/idlemove.ini
@@ -26,7 +26,8 @@ deafen = False
 channel = 0
 ; Channel the player has to be in for this treshold rule to affect him (-1 == Any)
 ;source_channel = -1
-
+; Comma seperated list of players that will not be moved when idle (such as bots) 
+whitelist = 
 ; For every server you want to override the [all] section for create
 ; a [server_<serverid>] section. For example:
 

--- a/modules/idlemove.py
+++ b/modules/idlemove.py
@@ -59,7 +59,7 @@ class idlemove(MumoModule):
                              ('deafen', commaSeperatedBool, [False]),
                              ('channel', commaSeperatedIntegers, [1]),
                              ('source_channel', commaSeperatedIntegers, [-1]),
-                             ('whitelist', commaSeperatedStrings, [''])
+                             ('whitelist', commaSeperatedStrings, [])
                              ),
                     }
     
@@ -225,5 +225,4 @@ class idlemove(MumoModule):
     def stopped(self, server, context = None):
         sid = server.id()
         self.affectedusers[sid] = set()
-        self.log().debug('Server %d gone', sid)
-    
+        self.log().debug('Server %d gone', sid) 

--- a/modules/idlemove.py
+++ b/modules/idlemove.py
@@ -39,6 +39,7 @@
 
 from mumo_module import (commaSeperatedIntegers,
                          commaSeperatedBool,
+                         commaSeperatedStrings,
                          MumoModule)
 
 from threading import Timer
@@ -57,7 +58,8 @@ class idlemove(MumoModule):
                              ('mute', commaSeperatedBool, [True]),
                              ('deafen', commaSeperatedBool, [False]),
                              ('channel', commaSeperatedIntegers, [1]),
-                             ('source_channel', commaSeperatedIntegers, [-1])
+                             ('source_channel', commaSeperatedIntegers, [-1]),
+                             ('whitelist', commaSeperatedStrings, [''])
                              ),
                     }
     
@@ -127,6 +129,10 @@ class idlemove(MumoModule):
             self.affectedusers[sid] = set()
             index = self.affectedusers[sid]
         
+        # Check if the user is whitelisted
+        if user.name in scfg.whitelist:
+            return
+
         # Remember values so we can see changes later
         threshold = None
         mute = user.mute


### PR DESCRIPTION
I've added the ability to define a list of users which are exempt from being moved by this module. This was useful for me since I have a few bots on my server which do not talk often.