### PR TITLE
Channel whitelist in idlemove

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 
 # Copyright (C) 2010 Stefan Hacker <dd0t@users.sourceforge.net>

--- a/config_test.py
+++ b/config_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 
 # Copyright (C) 2010 Stefan Hacker <dd0t@users.sourceforge.net>

--- a/modules-available/idlemove.ini
+++ b/modules-available/idlemove.ini
@@ -28,9 +28,11 @@ channel = 0
 ;source_channel = -1
 ; Comma seperated list of player names that will not be moved when idle (such as bots)
 whitelist =
+; Comma seperated list of channel ids from which players will not be moved even when idle.
+; channel_whitelist =
+
 ; For every server you want to override the [all] section for create
 ; a [server_<serverid>] section. For example:
-
 ; Overriding [all] for server with the id 1 would look like this
 ;[server_1]
 ;threshold = 60

--- a/modules/idlemove.py
+++ b/modules/idlemove.py
@@ -59,7 +59,8 @@ class idlemove(MumoModule):
                              ('deafen', commaSeperatedBool, [False]),
                              ('channel', commaSeperatedIntegers, [1]),
                              ('source_channel', commaSeperatedIntegers, [-1]),
-                             ('whitelist', commaSeperatedStrings, [])
+                             ('whitelist', commaSeperatedStrings, []),
+                             ('channel_whitelist', commaSeperatedIntegers, [])
                              ),
                     }
     
@@ -159,6 +160,7 @@ class idlemove(MumoModule):
                 continue
 
             if user.idlesecs > threshold and\
+                user.channel not in scfg.channel_whitelist and\
                 (source_channel == -1 or\
                  user.channel == source_channel or\
                  user.channel == channel):

--- a/mumo.py
+++ b/mumo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 
 # Copyright (C) 2010-2013 Stefan Hacker <dd0t@users.sourceforge.net>

--- a/mumo_manager.py
+++ b/mumo_manager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 
 # Copyright (C) 2010 Stefan Hacker <dd0t@users.sourceforge.net>

--- a/mumo_manager_test.py
+++ b/mumo_manager_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 
 # Copyright (C) 2010 Stefan Hacker <dd0t@users.sourceforge.net>

--- a/mumo_module.py
+++ b/mumo_module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 
 # Copyright (C) 2010 Stefan Hacker <dd0t@users.sourceforge.net>

--- a/testsuite.py
+++ b/testsuite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 
 # Copyright (C) 2010 Stefan Hacker <dd0t@users.sourceforge.net>

--- a/worker.py
+++ b/worker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 
 # Copyright (C) 2010 Stefan Hacker <dd0t@users.sourceforge.net>

--- a/worker_test.py
+++ b/worker_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 
 # Copyright (C) 2010 Stefan Hacker <dd0t@users.sourceforge.net>


### PR DESCRIPTION
This PR introduces a configurable channel whitelist to fix #8 . And while we have the chance of someone testing this also switch to the pep394 recommended style of specifying our python 2 which would've prevented #7 (though I still think it's archs' own fault for pulling this stunt).