### PR TITLE
fixed regex

### DIFF
--- a/modules/idlemove.py
+++ b/modules/idlemove.py
@@ -49,7 +49,7 @@ class idlemove(MumoModule):
         ('interval', float, 0.1),
         ('servers', commaSeperatedIntegers, []),
     ),
-        lambda x: re.match('(all)|(server_\d+)', x): (
+        lambda x: re.match(r'(all)|(server_\d+)', x): (
             ['threshold', commaSeperatedIntegers, [3600]],
             ('mute', commaSeperatedBool, [True]),
             ('deafen', commaSeperatedBool, [False]),


### PR DESCRIPTION
I had a warn when firing up mumo docker, stating that:

```
mumo  | /mumo/modules/idlemove.py:52: SyntaxWarning: invalid escape sequence '\d'
mumo  |   lambda x: re.match('(all)|(server_\d+)', x): (
```

and now it's gone.
Hopefully I did it right.